### PR TITLE
Removal of apt/yum cookbooks from tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -86,8 +86,6 @@ platforms:
 suites:
 - name: default
   run_list:
-  - recipe[apt]
-  - recipe[yum]
   - recipe[ssh-hardening::default]
   verifier:
     inspec_tests:

--- a/Berksfile
+++ b/Berksfile
@@ -3,6 +3,3 @@
 source 'https://supermarket.chef.io'
 
 metadata
-
-cookbook 'apt'
-cookbook 'yum'


### PR DESCRIPTION
They produce broken builds and we do not need them anymore:
https://travis-ci.org/dev-sec/chef-ssh-hardening/jobs/201236096